### PR TITLE
Remove old repo

### DIFF
--- a/includes/en/download/archlinux.php
+++ b/includes/en/download/archlinux.php
@@ -1,13 +1,3 @@
-<h2>Arch Linux</h2>
-<h3>Adding the archlinuxfr repository:</h3>
-<p>As root (or with sudo), add to <b>/etc/pacman.conf</b> the following lines (for i686 architectures):</p>
-<div class="codeconsole"><code>[archlinuxfr]<br />
-Server = http://repo.archlinux.fr/i686</code></div>
-
-<p>Or the following lines (for x86_64 architectures):</p>
-<div class="codeconsole"><code>[archlinuxfr]<br />
-Server = http://repo.archlinux.fr/x86_64</code></div>
-
-<h3>Installing PlayOnLinux</h3>
+<h1>Installing PlayOnLinux</h1>
 <p>As root (or with sudo), type the following command:</p>
 <div class="codeconsole"><code>pacman -Sy playonlinux</code></div>


### PR DESCRIPTION
This old repo that was listed for Arch has NO POL packages in it at all, and actually our current stable version is in their default repo's, so we can remove the steps for that old repo, as its not needed at all.
